### PR TITLE
fix(theme-switcher): prevent theme switcher from rendering with ssr

### DIFF
--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -1,13 +1,28 @@
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
 
 const ThemeSwitcher: FC = () => {
+  const [mounted, setMounted] = useState(false);
   const { theme, setTheme } = useTheme();
 
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
   return (
-    <button className="w-8 h-8 md:w-10 md:h-10" onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')} aria-label="Dark mode toggle">
+    <button
+      className="w-8 h-8"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      aria-label="Dark mode toggle"
+    >
       {theme === 'dark' ? (
-        <svg className="w-8 h-8 md:w-10 md:h-10" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg
+          className="w-8 h-8"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -16,7 +31,13 @@ const ThemeSwitcher: FC = () => {
           />
         </svg>
       ) : (
-        <svg className="w-8 h-8 md:w-10 md:h-10" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <svg
+          className="w-8 h-8"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
           <path
             strokeLinecap="round"
             strokeLinejoin="round"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,9 +32,7 @@ const Home: FC<HomeProps> = ({ posts }) => {
         <div className="md:h-screen text-lg bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 h-full flex flex-wrap content-between justify-between items-between p-10">
           <div className="w-full flex justify-between">
             <div className="text-2xl md:text-3xl font-light">codebycorey</div>
-            <div>
-              <ThemeSwitcher />
-            </div>
+            <ThemeSwitcher />
           </div>
           <div className="w-full">
             <h1 className="bg-clip-text text-transparent bg-gradient-to-l from-blue-700 dark:from-blue-500 to-green-500 text-4xl lg:text-8xl my-10 md:my-0 py-2 font-bold ">


### PR DESCRIPTION
Fixes #44 

# Dark Mode Hydration Issue

Prevent theme switcher from rendering in SSR. If the browser's default setting is dark, the server will still render the light mode.

## Solution
- Prevent render in SSR since `useEffect` does not execute until after first render.
- Reduce Icon side to prevent layout shift.
- Removed unnessary div. 